### PR TITLE
Fix billing reference structure for credit/debit notes

### DIFF
--- a/src/ZatcaInvoice.php
+++ b/src/ZatcaInvoice.php
@@ -138,7 +138,9 @@ class ZatcaInvoice
     {
         foreach ($invoiceData->getBillingReferences() as $reference) {
             $billingReference = $dom->createElement('cac:BillingReference');
-            $this->appendElement($dom, $billingReference, 'cbc:ID', $reference['id'] ?? '');
+            $invoiceDocumentReference = $dom->createElement('cac:InvoiceDocumentReference');
+            $this->appendElement($dom, $invoiceDocumentReference, 'cbc:ID', $reference['id'] ?? '');
+            $billingReference->appendChild($invoiceDocumentReference);
             $rootInvoice->appendChild($billingReference);
         }
     }


### PR DESCRIPTION
### Summary
This PR fixes the billing reference structure for credit and debit notes.

**Before:**
```xml
<cac:BillingReference>
    <cbc:ID>SME00002</cbc:ID>
</cac:BillingReference>
```

**After:**
```xml
<cac:BillingReference>
    <cac:InvoiceDocumentReference>
        <cbc:ID>SME00002</cbc:ID>
    </cac:InvoiceDocumentReference>
</cac:BillingReference>
```
**Why :** 
ZATCA requires credit/debit notes to have billing references wrapped inside <cac:InvoiceDocumentReference> (error code BR-KSA-56).
